### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/open-social-comments/_schema.yml
+++ b/_extensions/open-social-comments/_schema.yml
@@ -1,0 +1,23 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  mastodon_comments:
+    type: object
+    description: Mastodon source post details used to load comments.
+    properties:
+      user:
+        type: string
+        description: Mastodon account handle without leading @.
+      host:
+        type: string
+        description: Mastodon instance host name.
+      toot_id:
+        type: string
+        description: Status identifier from the Mastodon post URL.
+  bluesky_comments:
+    type: object
+    description: Bluesky source post details used to load comments.
+    properties:
+      post_uri:
+        type: string
+        description: Bluesky post URL to fetch and display comments for.

--- a/_extensions/open-social-comments/_snippets.json
+++ b/_extensions/open-social-comments/_snippets.json
@@ -1,0 +1,38 @@
+{
+  "Social comments with Mastodon": {
+    "prefix": "mastodon",
+    "body": [
+      "filters:",
+      "  - open-social-comments",
+      "mastodon_comments:",
+      "  user: \"${1:AndreasThinks}\"",
+      "  host: \"${2:fosstodon.org}\"",
+      "  toot_id: \"${3:111995180253316042}\""
+    ],
+    "description": "Enable Mastodon comments for a post."
+  },
+  "Social comments with Bluesky": {
+    "prefix": "bluesky",
+    "body": [
+      "filters:",
+      "  - open-social-comments",
+      "bluesky_comments:",
+      "  post_uri: \"${1:https://bsky.app/profile/user/post/postid}\""
+    ],
+    "description": "Enable Bluesky comments for a post."
+  },
+  "Social comments with both platforms": {
+    "prefix": "both",
+    "body": [
+      "filters:",
+      "  - open-social-comments",
+      "mastodon_comments:",
+      "  user: \"${1:AndreasThinks}\"",
+      "  host: \"${2:fosstodon.org}\"",
+      "  toot_id: \"${3:111995180253316042}\"",
+      "bluesky_comments:",
+      "  post_uri: \"${4:https://bsky.app/profile/user/post/postid}\""
+    ],
+    "description": "Enable both Mastodon and Bluesky comments."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/open-social-comments/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/open-social-comments/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
